### PR TITLE
Testing the waters with doctest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.10)
 project(LASER_Cloud_Viewer LANGUAGES C CXX)
 
+option(ENABLE_TESTS "Build unit tests with doctest" ON)
+
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
@@ -35,7 +37,7 @@ set(to_be_compiled
         )
 
 
-add_executable(test test.cpp ${to_be_compiled}) ## test executable, "laserViewer"
+add_executable(example_app test.cpp ${to_be_compiled}) ## test executable, "laserViewer"
 add_executable(test_open visualize.cpp ${to_be_compiled}) ## visualizer
 add_executable(test_register register.cpp ${to_be_compiled}) ## visualizer
 add_executable(test_noise_cancel noise_remover.cpp ${to_be_compiled}) ## 
@@ -43,10 +45,18 @@ add_executable(test_segment segemt.cpp ${to_be_compiled}) ##
 add_executable(test_save save.cpp ${to_be_compiled}) ## 
 add_executable(Laser_Cloud_Viewer ui.cxx ${to_be_compiled})
 
-target_link_libraries(test ${PCL_LIBRARIES} Boost::thread)
+target_link_libraries(example_app ${PCL_LIBRARIES} Boost::thread)
 target_link_libraries(test_open ${PCL_LIBRARIES} Boost::thread)
 target_link_libraries(test_register ${PCL_LIBRARIES} Boost::thread)
 target_link_libraries(test_noise_cancel ${PCL_LIBRARIES} Boost::thread)
 target_link_libraries(test_segment ${PCL_LIBRARIES} Boost::thread)
 target_link_libraries(test_save ${PCL_LIBRARIES} Boost::thread)
 target_link_libraries(Laser_Cloud_Viewer ${PCL_LIBRARIES} ${FLTK_LIBRARIES} ${OPENGL_LIBRARIES} Boost::thread)
+
+if(ENABLE_TESTS)
+    enable_testing()
+    add_executable(unit_tests tests/unit_tests.cpp ${to_be_compiled})
+    target_include_directories(unit_tests PRIVATE third_party)
+    target_link_libraries(unit_tests ${PCL_LIBRARIES} Boost::thread)
+    add_test(NAME unit_tests COMMAND unit_tests)
+endif()

--- a/tests/unit_tests.cpp
+++ b/tests/unit_tests.cpp
@@ -1,0 +1,23 @@
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include "doctest.h"
+#include "processing/cloud_processing.hpp"
+
+TEST_CASE("point_cut_off_floor removes outliers") {
+    pcl::PointCloud<pcl::PointXYZ>::Ptr cloud(new pcl::PointCloud<pcl::PointXYZ>);
+    pcl::PointXYZ p1; p1.x = 0; p1.y = 0; p1.z = 50;
+    pcl::PointXYZ p2; p2.x = 0; p2.y = 0; p2.z = 150;
+    pcl::PointXYZ p3; p3.x = 0; p3.y = 0; p3.z = 1000;
+    cloud->push_back(p1);
+    cloud->push_back(p2);
+    cloud->push_back(p3);
+
+    auto filtered = point_cut_off_floor(cloud);
+    CHECK(filtered->size() == 2);
+    bool has150 = false, has1000 = false;
+    for (const auto& p : filtered->points) {
+        if (p.z == doctest::Approx(150.f)) has150 = true;
+        if (p.z == doctest::Approx(1000.f)) has1000 = true;
+    }
+    CHECK(has150);
+    CHECK(has1000);
+}


### PR DESCRIPTION
## Summary
- integrate doctest unit testing
- add a sample test for `point_cut_off_floor`
- make building tests optional via `ENABLE_TESTS`

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest --output-on-failure`