### PR TITLE
Testing spree! 

### DIFF
--- a/processing/cloud_processing.cpp
+++ b/processing/cloud_processing.cpp
@@ -1,5 +1,12 @@
 #include "cloud_processing.hpp"
 
+float cut_min = 100.0f;
+float cut_max = 8000.0f;
+float reg_leaf_size = 100.0f;
+int noise_meanK = 50;
+float noise_stddev = 1.0f;
+int reg_iteration = 30;
+
 pcl::PointCloud<pcl::PointXYZRGB>::Ptr
 point_get_reg_from_vector(std::vector <pcl::PointCloud<pcl::PointXYZRGB>::Ptr> source_vector, float min, float max,
                           float leaf_size, int iteration) {
@@ -41,9 +48,9 @@ point_cloud_xyz_to_xyzrgb(pcl::PointCloud<pcl::PointXYZ>::Ptr xyz_cloud) {
     for (int i = 0; i < xyz_cloud->points.size(); i++) {
         pcl::PointXYZRGB point;
         //temporal point
-        point.x = rgb_cloud->points[i].x;
-        point.y = rgb_cloud->points[i].y;
-        point.z = rgb_cloud->points[i].z;
+        point.x = xyz_cloud->points[i].x;
+        point.y = xyz_cloud->points[i].y;
+        point.z = xyz_cloud->points[i].z;
         point.r = 255;
         point.g = 255;
         point.b = 255;

--- a/processing/cloud_processing.hpp
+++ b/processing/cloud_processing.hpp
@@ -1,11 +1,18 @@
-#include "../typedefs.h"
+#include <pcl/point_cloud.h>
+#include <pcl/point_types.h>
+#include <pcl/filters/voxel_grid.h>
+#include <pcl/filters/statistical_outlier_removal.h>
+#include <pcl/registration/icp.h>
+#include <pcl/registration/transforms.h>
+#include <Eigen/Dense>
+#include <vector>
 
-static float cut_min = 100.0f;
-static float cut_max = 8000.0f;
-static float reg_leaf_size = 100.0f;
-static int noise_meanK = 50;
-static float noise_stddev = 1.0f;
-static int reg_iteration = 30;
+extern float cut_min;
+extern float cut_max;
+extern float reg_leaf_size;
+extern int noise_meanK;
+extern float noise_stddev;
+extern int reg_iteration;
 
 pcl::PointCloud<pcl::PointXYZ>::Ptr point_cloud_xyzrgb_to_xyz(pcl::PointCloud<pcl::PointXYZRGB>::Ptr rgb_cloud);
 

--- a/tests/unit_tests.cpp
+++ b/tests/unit_tests.cpp
@@ -21,3 +21,49 @@ TEST_CASE("point_cut_off_floor removes outliers") {
     CHECK(has150);
     CHECK(has1000);
 }
+
+TEST_CASE("point_cloud_xyzrgb_to_xyz converts correctly") {
+    pcl::PointCloud<pcl::PointXYZRGB>::Ptr rgb(new pcl::PointCloud<pcl::PointXYZRGB>);
+    pcl::PointXYZRGB p; p.x = 1; p.y = 2; p.z = 3; p.r = 100; p.g = 150; p.b = 200;
+    rgb->push_back(p);
+    auto xyz = point_cloud_xyzrgb_to_xyz(rgb);
+    REQUIRE(xyz->size() == 1);
+    CHECK(xyz->points[0].x == doctest::Approx(1.f));
+    CHECK(xyz->points[0].y == doctest::Approx(2.f));
+    CHECK(xyz->points[0].z == doctest::Approx(3.f));
+}
+
+TEST_CASE("point_cloud_xyz_to_xyzrgb copies coordinates and assigns white") {
+    pcl::PointCloud<pcl::PointXYZ>::Ptr xyz(new pcl::PointCloud<pcl::PointXYZ>);
+    pcl::PointXYZ p; p.x = -1; p.y = -2; p.z = -3;
+    xyz->push_back(p);
+    auto rgb = point_cloud_xyz_to_xyzrgb(xyz);
+    REQUIRE(rgb->size() == 1);
+    CHECK(rgb->points[0].x == doctest::Approx(-1.f));
+    CHECK(rgb->points[0].y == doctest::Approx(-2.f));
+    CHECK(rgb->points[0].z == doctest::Approx(-3.f));
+    CHECK(rgb->points[0].r == 255);
+    CHECK(rgb->points[0].g == 255);
+    CHECK(rgb->points[0].b == 255);
+}
+
+TEST_CASE("point_downsample reduces duplicates") {
+    reg_leaf_size = 1.0f;
+    pcl::PointCloud<pcl::PointXYZ>::Ptr cloud(new pcl::PointCloud<pcl::PointXYZ>);
+    cloud->push_back(pcl::PointXYZ(0,0,0));
+    cloud->push_back(pcl::PointXYZ(0.2f,0.2f,0.2f));
+    cloud->push_back(pcl::PointXYZ(2,2,2));
+    auto filtered = point_downsample(cloud);
+    CHECK(filtered->size() == 2);
+}
+
+TEST_CASE("point_noise_removal eliminates outliers") {
+    noise_meanK = 1;
+    noise_stddev = 0.01f;
+    pcl::PointCloud<pcl::PointXYZ>::Ptr cloud(new pcl::PointCloud<pcl::PointXYZ>);
+    cloud->push_back(pcl::PointXYZ(0,0,0));
+    cloud->push_back(pcl::PointXYZ(0.1f,0.1f,0.1f));
+    cloud->push_back(pcl::PointXYZ(100,100,100));
+    auto filtered = point_noise_removal(cloud);
+    CHECK(filtered->size() == 2);
+}


### PR DESCRIPTION
## Summary
- refactor processing library globals for testability
- fix xyz->xyzrgb conversion
- widen unit test coverage

## Testing
- `g++ tests/unit_tests.cpp processing/cloud_processing.cpp -std=c++17 $(pkg-config --cflags pcl_common pcl_filters pcl_io pcl_registration) -Ithird_party -I. -o unit_tests $(pkg-config --libs pcl_common pcl_filters pcl_io pcl_registration)`
- `./unit_tests`