### PR TITLE
From Scale to Street: KITTI Converter Added

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ find_package(FLTK REQUIRED)
 find_package(OpenGL REQUIRED)
 find_package(OpenMP)
 find_package(Boost REQUIRED COMPONENTS thread)
+find_package(JsonCpp CONFIG REQUIRED)
 
 
 if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
@@ -34,6 +35,7 @@ set(to_be_compiled
         simple_vis/simple_vis.cpp
         processing/cloud_processing.cpp
         kitti/kitti_utils.cpp
+        kitti/scale_converter.cpp
         )
 
 
@@ -42,8 +44,9 @@ add_executable(test_open visualize.cpp ${to_be_compiled}) ## visualizer
 add_executable(test_register register.cpp ${to_be_compiled}) ## visualizer
 add_executable(test_noise_cancel noise_remover.cpp ${to_be_compiled}) ## 
 add_executable(test_segment segemt.cpp ${to_be_compiled}) ## 
-add_executable(test_save save.cpp ${to_be_compiled}) ## 
+add_executable(test_save save.cpp ${to_be_compiled}) ##
 add_executable(Laser_Cloud_Viewer ui.cxx ${to_be_compiled})
+add_executable(scale_to_kitti_cli scale_to_kitti_cli.cpp ${to_be_compiled})
 
 target_link_libraries(example_app ${PCL_LIBRARIES} Boost::thread)
 target_link_libraries(test_open ${PCL_LIBRARIES} Boost::thread)
@@ -52,11 +55,12 @@ target_link_libraries(test_noise_cancel ${PCL_LIBRARIES} Boost::thread)
 target_link_libraries(test_segment ${PCL_LIBRARIES} Boost::thread)
 target_link_libraries(test_save ${PCL_LIBRARIES} Boost::thread)
 target_link_libraries(Laser_Cloud_Viewer ${PCL_LIBRARIES} ${FLTK_LIBRARIES} ${OPENGL_LIBRARIES} Boost::thread)
+target_link_libraries(scale_to_kitti_cli JsonCpp::JsonCpp)
 
 if(ENABLE_TESTS)
     enable_testing()
     add_executable(unit_tests tests/unit_tests.cpp ${to_be_compiled})
     target_include_directories(unit_tests PRIVATE third_party)
-    target_link_libraries(unit_tests ${PCL_LIBRARIES} Boost::thread)
+    target_link_libraries(unit_tests ${PCL_LIBRARIES} Boost::thread JsonCpp::JsonCpp)
     add_test(NAME unit_tests COMMAND unit_tests)
 endif()

--- a/kitti/scale_converter.cpp
+++ b/kitti/scale_converter.cpp
@@ -1,0 +1,78 @@
+#include "scale_converter.hpp"
+#include <json/json.h>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+
+namespace fs = std::filesystem;
+
+bool convert_scale_to_kitti(const std::string &json_file,
+                            const std::string &output_dir) {
+    std::ifstream in(json_file);
+    if (!in.is_open()) {
+        std::cerr << "Cannot open " << json_file << std::endl;
+        return false;
+    }
+    Json::Value root;
+    in >> root;
+    if (!root.isObject()) {
+        std::cerr << "Invalid JSON format" << std::endl;
+        return false;
+    }
+    std::string image_path = root.get("image", "").asString();
+    fs::path image_fs(image_path);
+    std::string stem = image_fs.stem().string();
+
+    fs::create_directories(fs::path(output_dir) / "label_2");
+
+    std::ofstream label((fs::path(output_dir) / "label_2" / (stem + ".txt")).string());
+    if (!label.is_open()) {
+        std::cerr << "Cannot write label file" << std::endl;
+        return false;
+    }
+
+    const Json::Value anns = root["annotations"];
+    for (const auto &ann : anns) {
+        std::string type = ann.get("label", "").asString();
+        const auto &bbox = ann["bbox"];
+        float left = bbox.get("left", 0.f).asFloat();
+        float top = bbox.get("top", 0.f).asFloat();
+        float width = bbox.get("width", 0.f).asFloat();
+        float height = bbox.get("height", 0.f).asFloat();
+        float right = left + width;
+        float bottom = top + height;
+
+        const auto &dim = ann["dimensions"];
+        float h = dim.get("height", 0.f).asFloat();
+        float w = dim.get("width", 0.f).asFloat();
+        float l = dim.get("length", 0.f).asFloat();
+
+        const auto &loc = ann["location"];
+        float x = loc.get("x", 0.f).asFloat();
+        float y = loc.get("y", 0.f).asFloat();
+        float z = loc.get("z", 0.f).asFloat();
+
+        float ry = ann.get("rotation_y", 0.f).asFloat();
+
+        label << type << " 0 0 0 "
+              << left << ' ' << top << ' ' << right << ' ' << bottom << ' '
+              << h << ' ' << w << ' ' << l << ' '
+              << x << ' ' << y << ' ' << z << ' '
+              << ry << '\n';
+    }
+
+    label.close();
+
+    // copy image if exists
+    if (!image_path.empty()) {
+        fs::create_directories(fs::path(output_dir) / "image_2");
+        try {
+            fs::copy_file(image_fs, fs::path(output_dir) / "image_2" / image_fs.filename(),
+                           fs::copy_options::overwrite_existing);
+        } catch (const std::exception &e) {
+            std::cerr << "Failed to copy image: " << e.what() << std::endl;
+        }
+    }
+
+    return true;
+}

--- a/kitti/scale_converter.hpp
+++ b/kitti/scale_converter.hpp
@@ -1,0 +1,9 @@
+#ifndef SCALE_CONVERTER_HPP
+#define SCALE_CONVERTER_HPP
+
+#include <string>
+
+bool convert_scale_to_kitti(const std::string &json_file,
+                            const std::string &output_dir);
+
+#endif // SCALE_CONVERTER_HPP

--- a/scale_to_kitti_cli.cpp
+++ b/scale_to_kitti_cli.cpp
@@ -1,0 +1,15 @@
+#include "kitti/scale_converter.hpp"
+#include <iostream>
+
+int main(int argc, char **argv) {
+    if (argc != 3) {
+        std::cerr << "Usage: scale_to_kitti_cli <scale_json> <output_dir>" << std::endl;
+        return 1;
+    }
+    if (!convert_scale_to_kitti(argv[1], argv[2])) {
+        std::cerr << "Conversion failed" << std::endl;
+        return 1;
+    }
+    std::cout << "Conversion successful" << std::endl;
+    return 0;
+}

--- a/tests/unit_tests.cpp
+++ b/tests/unit_tests.cpp
@@ -1,6 +1,9 @@
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include "doctest.h"
 #include "processing/cloud_processing.hpp"
+#include "kitti/scale_converter.hpp"
+#include <fstream>
+#include <filesystem>
 
 TEST_CASE("point_cut_off_floor removes outliers") {
     pcl::PointCloud<pcl::PointXYZ>::Ptr cloud(new pcl::PointCloud<pcl::PointXYZ>);
@@ -20,4 +23,36 @@ TEST_CASE("point_cut_off_floor removes outliers") {
     }
     CHECK(has150);
     CHECK(has1000);
+}
+
+TEST_CASE("convert_scale_to_kitti writes label") {
+    namespace fs = std::filesystem;
+    const char* json_path = "tests/sample_scale.json";
+    const char* out_dir = "tests/tmp_out";
+    fs::create_directories(out_dir);
+    std::ofstream js(json_path);
+    js << "{\n"
+          "  \"image\": \"000000.png\",\n"
+          "  \"annotations\": [\n"
+          "    {\n"
+          "      \"label\": \"Car\",\n"
+          "      \"bbox\": {\"left\": 0, \"top\": 1, \"width\": 2, \"height\": 3},\n"
+          "      \"dimensions\": {\"height\": 1, \"width\": 2, \"length\": 3},\n"
+          "      \"location\": {\"x\": 4, \"y\": 5, \"z\": 6},\n"
+          "      \"rotation_y\": 0.5\n"
+          "    }\n"
+          "  ]\n"
+          "}\n";
+    js.close();
+
+    CHECK(convert_scale_to_kitti(json_path, out_dir));
+
+    std::ifstream label(std::string(out_dir) + "/label_2/000000.txt");
+    CHECK(label.is_open());
+    std::string line; std::getline(label, line);
+    CHECK(line.find("Car") != std::string::npos);
+    label.close();
+
+    fs::remove_all(out_dir);
+    fs::remove(json_path);
 }


### PR DESCRIPTION
## Summary
- convert ScaleAI output to KITTI format via `convert_scale_to_kitti`
- command line utility `scale_to_kitti_cli`
- integrate JsonCpp
- add unit test for conversion

## Testing
- `cmake ..` *(fails: missing FLTK)*