### PR TITLE
CMake gets a glow up

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,16 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
+
+# Adopt modern CMake policies when available
+if(POLICY CMP0144)
+    cmake_policy(SET CMP0144 NEW) # find_package uses <PACKAGENAME>_ROOT
+endif()
+if(POLICY CMP0072)
+    cmake_policy(SET CMP0072 NEW) # Prefer GLVND for OpenGL
+endif()
+if(POLICY CMP0167)
+    cmake_policy(SET CMP0167 NEW) # FindBoost module removed
+endif()
+
 project(LASER_Cloud_Viewer LANGUAGES C CXX)
 
 option(ENABLE_TESTS "Build unit tests with doctest" ON)
@@ -22,11 +34,7 @@ if (OpenMP_CXX_FOUND)
     add_compile_options(${OpenMP_CXX_FLAGS})
 endif()
 
-##PCL
-include_directories(${PCL_INCLUDE_DIRS} ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
-link_directories(${PCL_LIBRARY_DIRS})
-add_definitions(${PCL_DEFINITIONS})
-##PCL
+## PCL include directories are provided by the imported targets
 
 set(LCV_SOURCES
     model.cpp
@@ -37,11 +45,11 @@ set(LCV_SOURCES
 )
 
 add_library(lcv STATIC ${LCV_SOURCES})
+target_compile_features(lcv PUBLIC cxx_std_17)
 target_include_directories(lcv PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(lcv PUBLIC ${PCL_LIBRARIES} Boost::thread)
 
 
-add_executable(demo_app demo.cpp)
 add_executable(test_open visualize.cpp)
 add_executable(test_register register.cpp)
 add_executable(test_noise_cancel noise_remover.cpp)
@@ -49,7 +57,6 @@ add_executable(test_segment segemt.cpp)
 add_executable(test_save save.cpp)
 add_executable(Laser_Cloud_Viewer ui.cxx)
 
-target_link_libraries(demo_app lcv)
 target_link_libraries(test_open lcv)
 target_link_libraries(test_register lcv)
 target_link_libraries(test_noise_cancel lcv)


### PR DESCRIPTION
## Summary
- update minimum CMake version and adopt new policies
- simplify PCL setup and modernize target features
- drop stray demo_app target

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest --output-on-failure` *(fails: missing sample files)*

------
https://chatgpt.com/codex/tasks/task_e_684e84b5962c832d99cdf87d59eeac7e