### PR TITLE
Keeping up with the PCLs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ option(ENABLE_TESTS "Build unit tests with doctest" ON)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-find_package(PCL 1.15 REQUIRED)
+find_package(PCL 1.14 REQUIRED)
 find_package(MPI REQUIRED)
 find_package(FLTK REQUIRED)
 find_package(OpenGL REQUIRED)

--- a/file/opener.hpp
+++ b/file/opener.hpp
@@ -5,7 +5,7 @@
 #include <algorithm>
 #include <iterator>
 
-#include <pcl/io/io.h>
+#include <pcl/common/io.h>
 #include <pcl/io/pcd_io.h>
 #include <pcl/io/vtk_io.h>
 #include <pcl/io/vtk_lib_io.h>

--- a/processing/cloud_processing.hpp
+++ b/processing/cloud_processing.hpp
@@ -3,7 +3,7 @@
 #include <pcl/filters/voxel_grid.h>
 #include <pcl/filters/statistical_outlier_removal.h>
 #include <pcl/registration/icp.h>
-#include <pcl/registration/transforms.h>
+#include <pcl/common/transforms.h>
 #include <Eigen/Dense>
 #include <vector>
 

--- a/typedefs.h
+++ b/typedefs.h
@@ -35,7 +35,7 @@
 #include <pcl/search/search.h>
 #include <pcl/search/kdtree.h>
 
-#include <pcl/io/io.h>
+#include <pcl/common/io.h>
 #include <pcl/io/pcd_io.h>
 #include <pcl/io/vtk_io.h>
 #include <pcl/io/vtk_lib_io.h>
@@ -50,7 +50,7 @@
 
 #include <pcl/registration/icp.h>
 #include <pcl/registration/icp_nl.h>
-#include <pcl/registration/transforms.h>
+#include <pcl/common/transforms.h>
 
 #include <pcl/sample_consensus/method_types.h>
 #include <pcl/sample_consensus/model_types.h>


### PR DESCRIPTION
## Summary
- require PCL 1.14 in CMake
- switch deprecated headers to their modern equivalents

## Testing
- `cmake -DPCL_DIR=/usr/lib/x86_64-linux-gnu/cmake/pcl ..`
- `make -j2`
- `ctest --output-on-failure` *(fails: missing sample data)*


------
https://chatgpt.com/codex/tasks/task_e_684ec598c2f8832d968727683ed992a7