### PR TITLE
Colorful fix for point conversions

### DIFF
--- a/file/opener.cpp
+++ b/file/opener.cpp
@@ -7,10 +7,10 @@ open_point_cloud_xyz_to_xyzrgb(pcl::PointCloud<pcl::PointXYZ>::Ptr xyz_cloud) {
 #pragma omp parallel for
     for (int i = 0; i < xyz_cloud->points.size(); i++) {
         pcl::PointXYZRGB point;
-        // temporal point
-        point.x = rgb_cloud->points[i].x;
-        point.y = rgb_cloud->points[i].y;
-        point.z = rgb_cloud->points[i].z;
+        // copy coordinates from source cloud
+        point.x = xyz_cloud->points[i].x;
+        point.y = xyz_cloud->points[i].y;
+        point.z = xyz_cloud->points[i].z;
         point.r = 255;
         point.g = 255;
         point.b = 255;

--- a/file/opener.hpp
+++ b/file/opener.hpp
@@ -19,6 +19,9 @@
 #include <boost/tokenizer.hpp>
 #include <omp.h>
 
+pcl::PointCloud<pcl::PointXYZRGB>::Ptr
+open_point_cloud_xyz_to_xyzrgb(pcl::PointCloud<pcl::PointXYZ>::Ptr xyz_cloud);
+
 pcl::PointCloud<pcl::PointXYZRGB>::Ptr point_cloud_from_txt(std::string file_path);
 
 pcl::PointCloud<pcl::PointXYZRGB>::Ptr point_cloud_open_pcd_file(std::string file_path);

--- a/main.cpp
+++ b/main.cpp
@@ -1,10 +1,11 @@
 #include "ui.h"
 
 int main(int argc, char **argv) {
-    // initialize class
+    // initialize UI application
     laserApp app;
-    app.show;
+    app.basicWindow->show(argc, argv);
+    app.advancedWindow->show(argc, argv);
     std::cout << "Initialized" << std::endl;
 
-    return 0;
+    return Fl::run();
 }

--- a/tests/unit_tests.cpp
+++ b/tests/unit_tests.cpp
@@ -70,6 +70,19 @@ TEST_CASE("point_cloud_xyz_to_xyzrgb copies coordinates and assigns white") {
     CHECK(rgb->points[0].b == 255);
 }
 
+TEST_CASE("open_point_cloud_xyz_to_xyzrgb wraps XYZ input") {
+    pcl::PointCloud<pcl::PointXYZ>::Ptr xyz(new pcl::PointCloud<pcl::PointXYZ>);
+    xyz->push_back(pcl::PointXYZ(1.0f, 2.0f, 3.0f));
+    auto rgb = open_point_cloud_xyz_to_xyzrgb(xyz);
+    REQUIRE(rgb->size() == 1);
+    CHECK(rgb->points[0].x == doctest::Approx(1.f));
+    CHECK(rgb->points[0].y == doctest::Approx(2.f));
+    CHECK(rgb->points[0].z == doctest::Approx(3.f));
+    CHECK(rgb->points[0].r == 255);
+    CHECK(rgb->points[0].g == 255);
+    CHECK(rgb->points[0].b == 255);
+}
+
 TEST_CASE("point_downsample reduces duplicates") {
     reg_leaf_size = 1.0f;
     pcl::PointCloud<pcl::PointXYZ>::Ptr cloud(new pcl::PointCloud<pcl::PointXYZ>);


### PR DESCRIPTION
## Summary
- correct coordinate copy in `open_point_cloud_xyz_to_xyzrgb`
- expose the helper in the header
- add a unit test to verify conversion logic
- fix `main.cpp` to display windows

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685614568f64832dad363079f6a4e230